### PR TITLE
Fix post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "FWeinb/node-webkit-screenshot",
   "main": "index.js",
   "scripts": {
-    "postinstall": "npm install --prefix ./nw-screenshot",
+    "postinstall": "cd nw-screenshot && npm install",
     "test": "mocha test"
   },
   "keywords": [


### PR DESCRIPTION
the npm install --prefix uses your local package.json and reinstalls the whole bundle of dependencies inside the given directory.

This was causing a recursive loop.
